### PR TITLE
feat: update compare_batches.sh to ignore .batchTTL field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,8 @@ go.work.sum
 # Folders
 dist/
 .vscode/
+
+**/1.txt
+**/2.txt
+**/tmp1.json
+**/tmp2.json

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:3.20
+
+RUN apk add --no-cache bash curl jq diffutils
+
+COPY compare_batches.sh /compare_batches.sh
+RUN chmod +x /compare_batches.sh
+
+ENTRYPOINT ["/compare_batches.sh"]

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,11 +7,13 @@ This directory contains the `compare_batches.sh` script for comparing batch data
 To use the `compare_batches.sh` script:
 
 1. Make the script executable:
+
    ```bash
    chmod +x compare_batches.sh
    ```
 
 2. Run it with two domain names:
+
    ```bash
    ./compare_batches.sh localhost:1633 other_domain
    ```
@@ -32,3 +34,12 @@ The `compare_batches.sh` script:
 ## Output
 
 The script will display differences between the two batch endpoints side by side, or report "No differences found" if the responses are identical.
+
+## Build & Push
+
+To build and push the Docker image for this script, you can use the following commands:
+
+```bash
+docker build -t your_dockerhub_username/compare_batches.sh:latest .
+docker push your_dockerhub_username/compare_batches.sh:latest
+```

--- a/scripts/compare_batches.sh
+++ b/scripts/compare_batches.sh
@@ -62,4 +62,5 @@ if diff --side-by-side --suppress-common-lines "$FILE1" "$FILE2"; then
     rm -f "$TMP1" "$TMP2"
 else
     echo "Differences found (see above)."
+    exit 1
 fi

--- a/scripts/compare_batches.sh
+++ b/scripts/compare_batches.sh
@@ -58,8 +58,8 @@ jq '.batches | map(del(.batchTTL))' "$TMP2" > "$FILE2"
 # Compare the files and show differences side by side
 echo "Differences between ${FILE1} and ${FILE2} (side by side):"
 if diff --side-by-side --suppress-common-lines "$FILE1" "$FILE2"; then
-    echo "No differences found. Cleaning up..."
-    rm -f "$FILE1" "$FILE2" "$TMP1" "$TMP2"
+    echo "No differences found."
+    rm -f "$TMP1" "$TMP2"
 else
     echo "Differences found (see above)."
 fi

--- a/scripts/compare_batches.sh
+++ b/scripts/compare_batches.sh
@@ -10,14 +10,16 @@ DOMAIN1=$1
 DOMAIN2=$2
 FILE1="1.txt"
 FILE2="2.txt"
+TMP1="tmp1.json"
+TMP2="tmp2.json"
 
-# Perform curl requests in parallel
-curl -s "http://${DOMAIN1}/batches" | jq > "$FILE1" &
+# Fetch both responses in parallel
+curl -s "http://${DOMAIN1}/batches" > "$TMP1" &
 PID1=$!
-curl -s "http://${DOMAIN2}/batches" | jq > "$FILE2" &
+curl -s "http://${DOMAIN2}/batches" > "$TMP2" &
 PID2=$!
 
-# Wait for both curl commands to complete
+# Wait and check each curl
 wait $PID1
 if [ $? -ne 0 ]; then
     echo "Error fetching data from ${DOMAIN1}"
@@ -30,13 +32,34 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
+# Get batch counts
+COUNT1=$(jq '.batches | length' "$TMP1" 2>/dev/null)
+COUNT2=$(jq '.batches | length' "$TMP2" 2>/dev/null)
+
+# Validate batch presence
+if [ -z "$COUNT1" ] || [ "$COUNT1" -eq 0 ]; then
+    echo "No batches found in response from ${DOMAIN1}"
+    exit 1
+fi
+
+if [ -z "$COUNT2" ] || [ "$COUNT2" -eq 0 ]; then
+    echo "No batches found in response from ${DOMAIN2}"
+    exit 1
+fi
+
+# Print batch counts
+echo "Batch count from ${DOMAIN1}: $COUNT1"
+echo "Batch count from ${DOMAIN2}: $COUNT2"
+
+# Strip batchTTL and save for comparison
+jq '.batches | map(del(.batchTTL))' "$TMP1" > "$FILE1"
+jq '.batches | map(del(.batchTTL))' "$TMP2" > "$FILE2"
+
 # Compare the files and show differences side by side
 echo "Differences between ${FILE1} and ${FILE2} (side by side):"
-diff --side-by-side --suppress-common-lines "$FILE1" "$FILE2"
-
-# Check if there were any differences
-if [ $? -eq 0 ]; then
-    echo "No differences found."
+if diff --side-by-side --suppress-common-lines "$FILE1" "$FILE2"; then
+    echo "No differences found. Cleaning up..."
+    rm -f "$FILE1" "$FILE2" "$TMP1" "$TMP2"
 else
     echo "Differences found (see above)."
 fi


### PR DESCRIPTION
Idea is to use this script in some cronjob to verify the `batches`, but because sometimes BatchTTL is not the same which is depending on the different chainstate of two compareing nodes, `batchTTL` is removed from comparisson. Other fields in the response are compared to have same contents.